### PR TITLE
Release 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphatango/exceptions",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Custom error models",
   "main": "lib/index.js",
   "private": false,
@@ -27,9 +27,12 @@
   },
   "homepage": "https://github.com/Cimpress-MCP/AT-Exceptions#readme",
   "dependencies": {},
-  "peerDependencies": {},
+  "peerDependencies": {
+    "axios": "~0.19.2"
+  },
   "devDependencies": {
     "@types/jest": "26.0.8",
+    "axios": "0.19.2",
     "eslint": "7.5.0",
     "eslint-config-cimpress-atsquad": "2.1.2",
     "husky": "4.2.5",

--- a/src/exceptions/clientException.ts
+++ b/src/exceptions/clientException.ts
@@ -1,31 +1,30 @@
+import { AxiosError } from 'axios';
 import { Exception } from './exception';
+import { isAxiosError } from '../util';
 
 export class ClientException extends Exception {
   private static readonly statusCodeMap: Record<number, number> = {
     400: 422,
-    401: 401,
-    403: 403,
     404: 422,
   };
 
-  constructor(serviceName: string, error?: unknown) {
-    super('Dependent service returned error', ClientException.convertStatusCode(error as object), {
+  constructor(serviceName: string, error?: AxiosError | unknown) {
+    super('Dependent service returned error', ClientException.convertStatusCode(error), {
       error,
       serviceName,
     });
   }
 
-  private static convertStatusCode(details?: object) {
+  private static convertStatusCode(details?: AxiosError | unknown) {
     let statusCode = 503;
-    let originalStatusCode;
-    if (details && 'statusCode' in details) {
-      originalStatusCode = parseInt((details as any).statusCode, 10);
-    } else if (details && 'status' in details) {
-      originalStatusCode = parseInt((details as any).status, 10);
+
+    if (isAxiosError(details)) {
+      const originalStatusCode = details.response?.status;
+      if (originalStatusCode && this.statusCodeMap[originalStatusCode]) {
+        statusCode = this.statusCodeMap[originalStatusCode];
+      }
     }
-    if (this.statusCodeMap[originalStatusCode]) {
-      statusCode = this.statusCodeMap[originalStatusCode];
-    }
+
     return statusCode;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { InternalException } from './exceptions/internalException';
 import { InvalidDataException } from './exceptions/invalidDataException';
 import { NotFoundException } from './exceptions/notFoundException';
 import { ValidationException } from './exceptions/validationException';
-import { serialize } from './util';
+import { isAxiosError, serialize } from './util';
 
 export {
   ValidationException,
@@ -18,4 +18,5 @@ export {
   ConflictException,
   ClientException,
   serialize,
+  isAxiosError,
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,9 @@
+import { AxiosError } from 'axios';
+
 export function serialize(obj: unknown): object {
   return JSON.parse(JSON.stringify(obj, Object.getOwnPropertyNames(obj)));
+}
+
+export function isAxiosError(error: unknown): error is AxiosError {
+  return (error as AxiosError).isAxiosError;
 }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,4 +1,4 @@
-import { serialize } from '../src/util';
+import { isAxiosError, serialize } from '../src/util';
 
 describe('Util', () => {
   const message = 'tests-error-message';
@@ -12,6 +12,20 @@ describe('Util', () => {
       };
       const serializedError = serialize(error);
       expect(serializedError).toEqual(expected);
+    });
+  });
+
+  describe('isAxiosError', () => {
+    test('works as type predicate', () => {
+      const testError: unknown = {
+        isAxiosError: true,
+        response: { status: 200 },
+      };
+
+      // without the if condition, this would be a typescript compile error
+      if (isAxiosError(testError)) {
+        expect(testError.response?.status).toEqual(200);
+      }
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,6 +966,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
@@ -1414,6 +1421,13 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
@@ -2067,6 +2081,13 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- type the details object in ClientException so that the original
  AxiosError can be inspected safely
- now this peerDepends on Axios provided by others who want to
  throw the ClientException