### PR TITLE
Release 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphatango/exceptions",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Custom error models",
   "main": "lib/index.js",
   "private": false,

--- a/src/exceptions/clientException.ts
+++ b/src/exceptions/clientException.ts
@@ -3,8 +3,12 @@ import { Exception } from './exception';
 import { isAxiosError } from '../util';
 
 export class ClientException extends Exception {
+  public readonly originalStatusCode?: number;
+
   private static readonly statusCodeMap: Record<number, number> = {
     400: 422,
+    401: 401,
+    403: 403,
     404: 422,
   };
 
@@ -13,6 +17,8 @@ export class ClientException extends Exception {
       error,
       serviceName,
     });
+
+    this.originalStatusCode = isAxiosError(error) ? error.response?.status : undefined;
   }
 
   private static convertStatusCode(details?: AxiosError | unknown) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,17 @@
 import { AxiosError } from 'axios';
 
 export function serialize(obj: unknown): object {
-  return JSON.parse(JSON.stringify(obj, Object.getOwnPropertyNames(obj)));
+  if (obj && typeof obj === 'object') {
+    return Object.getOwnPropertyNames(obj).reduce((map, key) => {
+      // eslint-disable-next-line no-param-reassign
+      map[key] = obj[key];
+      return map;
+    }, {});
+  }
+
+  return JSON.parse(JSON.stringify(obj));
 }
 
 export function isAxiosError(error: unknown): error is AxiosError {
-  return (error as AxiosError).isAxiosError;
+  return (error as AxiosError)?.isAxiosError;
 }

--- a/tests/exceptions/clientException.test.ts
+++ b/tests/exceptions/clientException.test.ts
@@ -1,0 +1,63 @@
+import { AxiosError } from 'axios';
+import { ClientException } from '../../src';
+
+interface AxiosErrorTestData {
+  originalStatusCode: number;
+  exceptionStatusCode: number;
+}
+
+describe('ClientException', () => {
+  describe('converts Axios errors', () => {
+    const testServiceName = 'test-service-name';
+
+    const createAxiosError = (status: number): AxiosError => ({
+      isAxiosError: true,
+      config: {},
+      toJSON: () => ({}),
+      name: 'test axios error name',
+      message: 'test axios error message',
+      response: {
+        config: {},
+        headers: {},
+        request: {},
+        data: {},
+        statusText: 'test axios error status text',
+        status,
+      },
+    });
+
+    const testData: AxiosErrorTestData[] = [
+      {
+        originalStatusCode: 400,
+        exceptionStatusCode: 422,
+      },
+      {
+        originalStatusCode: 401,
+        exceptionStatusCode: 401,
+      },
+      {
+        originalStatusCode: 403,
+        exceptionStatusCode: 403,
+      },
+      {
+        originalStatusCode: 404,
+        exceptionStatusCode: 422,
+      },
+    ];
+
+    testData.map(({ exceptionStatusCode, originalStatusCode }) =>
+      test(`from ${originalStatusCode} to ${exceptionStatusCode}`, () => {
+        const axiosError = createAxiosError(originalStatusCode);
+        const clientException = new ClientException(testServiceName, axiosError);
+
+        expect(clientException.message).toEqual('Dependent service returned error');
+        expect(clientException.originalStatusCode).toEqual(originalStatusCode);
+        expect(clientException.statusCode).toEqual(exceptionStatusCode);
+        expect(clientException.details).toEqual({
+          serviceName: testServiceName,
+          error: axiosError,
+        });
+      }),
+    );
+  });
+});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,4 +1,4 @@
-import { isAxiosError, serialize } from '../src/util';
+import { isAxiosError, serialize } from '../src';
 
 describe('Util', () => {
   const message = 'tests-error-message';
@@ -11,6 +11,27 @@ describe('Util', () => {
         stack: expect.any(String),
       };
       const serializedError = serialize(error);
+      expect(serializedError).toEqual(expected);
+    });
+
+    test('serializes Error string', () => {
+      const expected = 'test-error-string';
+      const serializedError = serialize(expected);
+      expect(serializedError).toEqual(expected);
+    });
+
+    test('serializes Error object', () => {
+      const expected = {
+        stringProp: 'string-prop-value',
+        objectProp: {
+          innerProp: 'inner-prop-value',
+          innerObjectProp: {
+            innerObjectPropKey: 'inner-object-prop-value',
+          },
+        },
+      };
+
+      const serializedError = serialize(expected);
       expect(serializedError).toEqual(expected);
     });
   });
@@ -26,6 +47,10 @@ describe('Util', () => {
       if (isAxiosError(testError)) {
         expect(testError.response?.status).toEqual(200);
       }
+    });
+
+    test('returns false when the error is undefined', () => {
+      expect(isAxiosError(undefined)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Add originalStatusCode property to ClientException to make
error handling depending on the response status code easier

Also re-add mapping of 401/403 to 401/403 instead of defaulting to 503.